### PR TITLE
Set up API 37 emulator in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,15 +295,36 @@ jobs:
   android:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # The pre-release API 37 emulator image is still maturing, so let the entry marked
+    # experimental fail without blocking the build until the image is stable on CI.
+    continue-on-error: ${{ matrix.experimental || false }}
 
     strategy:
       fail-fast: false
       matrix:
-        api-level:
-          - 21
-          - 23
-          - 29
-          - 34
+        include:
+          - api-level: 21
+            arch: x86
+            target: default
+          - api-level: 23
+            arch: x86
+            target: default
+          - api-level: 29
+            arch: x86
+            target: default
+          - api-level: 34
+            arch: x86_64
+            target: default
+          # API 37 only ships 16 KB page-size images; playstore_ps16k resolves to
+          # google_apis_playstore_ps16k. Quoted so YAML keeps the ".0".
+          - api-level: "37.0"
+            arch: x86_64
+            target: playstore_ps16k
+            # API 37 needs more headroom than the other levels.
+            memory: 4096
+            gpu: -gpu auto
+            # Pre-release emulator image; allowed to fail (see continue-on-error above).
+            experimental: true
 
     steps:
       - name: Checkout
@@ -331,14 +352,17 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Gradle cache
-        run: ./gradlew :android-test:test
+      - name: Warm the Gradle cache
+        # Build the instrumentation APK to warm the cache, but don't run the Robolectric unit
+        # tests (`:android-test:test`) here: they fetch the android-all artifact and can take
+        # ~30 min.
+        run: ./gradlew :android-test:assembleDebugAndroidTest
 
       - name: AVD System Image Cache
         uses: actions/cache@v6
         id: avd-cache
         with:
-          key: avd-${{ runner.os }}-${{ matrix.api-level }}-${{ matrix.api-level >= 30 && 'x86_64' || 'x86' }}
+          key: avd-${{ runner.os }}-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}
           path: |
             ~/.android/avd/*
             ~/.android/adb*
@@ -351,15 +375,18 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           force-avd-creation: false
-          arch: ${{ matrix.api-level >= 30 && 'x86_64' || 'x86' }}
-          # No window, no audio, and use swiftshader for headless environments
+          target: ${{ matrix.target }}
+          arch: ${{ matrix.arch }}
+          emulator-boot-timeout: 120
+          # No window, no audio, and use dynamic GPU and feature flags for headless environments
           emulator-options: >
             -no-window
-            -gpu swiftshader_indirect
+            ${{ matrix.gpu || '-gpu swiftshader_indirect' }}
             -noaudio
             -no-boot-anim
             -camera-back none
-            -memory 2048
+            -memory ${{ matrix.memory || '2048' }}
+            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
           disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
@@ -367,7 +394,20 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          arch: ${{ matrix.api-level == '34' && 'x86_64' || 'x86' }}
+          target: ${{ matrix.target }}
+          arch: ${{ matrix.arch }}
+          emulator-boot-timeout: 120
+          # These must match the options used to create the snapshot above: the emulator only
+          # restores a cached snapshot when the boot options are identical. The action default
+          # includes -no-snapshot, which would otherwise force a slow cold boot.
+          emulator-options: >
+            -no-window
+            ${{ matrix.gpu || '-gpu swiftshader_indirect' }}
+            -noaudio
+            -no-boot-anim
+            -camera-back none
+            -memory ${{ matrix.memory || '2048' }}
+            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
           script: ./gradlew -PandroidBuild=true connectedCheck
         env:
           API_LEVEL: ${{ matrix.api-level }}

--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -47,9 +47,11 @@ import mockwebserver3.MockWebServer
 import mockwebserver3.junit5.StartStop
 import okhttp3.Cache
 import okhttp3.Call
+import okhttp3.CallEvent
 import okhttp3.CallEvent.CallEnd
 import okhttp3.CallEvent.CallStart
 import okhttp3.CallEvent.ConnectEnd
+import okhttp3.CallEvent.ConnectFailed
 import okhttp3.CallEvent.ConnectStart
 import okhttp3.CallEvent.ConnectionAcquired
 import okhttp3.CallEvent.ConnectionReleased
@@ -328,7 +330,10 @@ class OkHttpTest {
         assertEquals(Protocol.HTTP_2, response.protocol)
         assertEquals(200, response.code)
         assertEquals("com.google.android.gms.org.conscrypt.Java8FileDescriptorSocket", socketClass)
-        assertEquals(TlsVersion.TLS_1_2, response.handshake?.tlsVersion)
+        // The GmsCore Conscrypt provider negotiates TLS 1.3 from the API 37 image onward; earlier
+        // emulator images cap this handshake at TLS 1.2.
+        val expectedTls = if (Build.VERSION.SDK_INT >= 37) TlsVersion.TLS_1_3 else TlsVersion.TLS_1_2
+        assertEquals(expectedTls, response.handshake?.tlsVersion)
       }
     } finally {
       Security.removeProvider("GmsCore_OpenSSL")
@@ -546,7 +551,15 @@ class OkHttpTest {
     try {
       client.newCall(request).execute()
       fail<Any>("")
-    } catch (_: SSLPeerUnverifiedException) {
+    } catch (e: Exception) {
+      // The API 37 emulator can surface the verification failure wrapped (as a cause or a
+      // suppressed exception) rather than thrown directly, so accept any of those shapes.
+      val hasPeerUnverified = e is SSLPeerUnverifiedException ||
+          e.suppressedExceptions.any { it is SSLPeerUnverifiedException } ||
+          e.cause is SSLPeerUnverifiedException
+      if (!hasPeerUnverified) {
+        throw e
+      }
     }
   }
 
@@ -617,7 +630,7 @@ class OkHttpTest {
         ConnectionReleased::class,
         CallEnd::class,
       ),
-      eventRecorder.recordedEventTypes(),
+      eventRecorder.eventSequence.toList().withoutFailedConnectAttempts().map { it::class },
     )
 
     eventRecorder.clearAllEvents()
@@ -643,6 +656,23 @@ class OkHttpTest {
       eventRecorder.recordedEventTypes(),
     )
   }
+
+  /**
+   * Returns these events with failed connection attempts removed. On a dual-stack loopback the
+   * address MockWebServer isn't bound to is tried first, producing a [ConnectStart]/[ConnectFailed]
+   * pair before the successful [ConnectStart] (seen on the API 37 emulator). Dropping those pairs
+   * keeps the event assertion stable across single- and dual-stack environments.
+   */
+  private fun List<CallEvent>.withoutFailedConnectAttempts(): List<CallEvent> =
+    fold(mutableListOf<CallEvent>()) { events, event ->
+      if (event is ConnectFailed) {
+        // Drop the ConnectFailed and the ConnectStart that opened the failed attempt.
+        if (events.lastOrNull() is ConnectStart) events.removeAt(events.lastIndex)
+      } else {
+        events += event
+      }
+      events
+    }
 
   @Test
   fun testSessionReuse() {


### PR DESCRIPTION
Splits the emulator/CI setup out of the `testing_ech` branch so it can land ahead of the ECH platform work.

## CI emulator setup (`.github/workflows/build.yml`)

- Drive the `android` job's matrix off an explicit `include` list with per-entry `target`/`arch`, replacing the inline `>= 30` / `== '34'` ternaries.
- Add an experimental API 37 entry on the 16 KB page-size `playstore_ps16k` image, with extra memory (4096), `-gpu auto`, and `continue-on-error` so the still-maturing pre-release image can fail without blocking the build.
- Warm the Gradle cache by assembling the instrumentation APK (`:android-test:assembleDebugAndroidTest`) instead of running the Robolectric unit tests (`:android-test:test`), which fetch the `android-all` artifact and can take ~30 min.
- Key the AVD cache on `target`-`arch`, and match the snapshot boot options on the run step (boot timeout, GPU/memory flags, `-feature GLDirectMem,HasSharedSlotsHostMemoryAllocator`) so cached snapshots actually restore instead of cold-booting.

## API 37 instrumentation test fixes (`android-test/.../OkHttpTest.kt`)

Three environmental differences surface on the API 37 emulator image and make `connectedCheck` fail there. All are independent of the Android 17 platform/ECH code:

- The GmsCore Conscrypt provider negotiates TLS 1.3 (not 1.2) from API 37 onward — assert the version conditionally.
- The dual-stack loopback tries the unbound address first, emitting a `ConnectStart`/`ConnectFailed` pair before the successful connect — filter those pairs out so the event-sequence assertion is stable across single- and dual-stack environments.
- Peer-verification failures can arrive wrapped (as a cause or suppressed exception) rather than thrown directly — accept any of those shapes.

## Deliberately left out

The Android 17 platform layer from `testing_ech` (`Android17Platform`, `Android17SocketAdapter`, the `configureTlsExtensions(call, …)` signature change, and the `Platform.echModeConfiguration`/`platformAsyncDns` hooks) is inseparable from the ECH feature, so it is **not** included here. The API 37 job is marked experimental/non-blocking precisely so this infrastructure can land first; full API 37 platform behaviour arrives with the ECH PR.

## Test plan

- API 37 entry runs on the `playstore_ps16k` emulator image under `continue-on-error`.
- Existing API 21/23/29/34 entries unchanged except for the explicit `target`/`arch` matrix.